### PR TITLE
Fix IndexError when parsing versions with local suffixes (#1469)

### DIFF
--- a/clearml/utilities/version.py
+++ b/clearml/utilities/version.py
@@ -331,13 +331,19 @@ class Version(_BaseVersion):
             # Versions without a local segment should sort before those with one.
             local = inf
         else:
-            # Versions with a local segment need that segment parsed to implement
-            # the sorting rules in PEP440.
-            # - Alpha numeric segments sort before numeric segments
-            # - Alpha numeric segments sort lexicographically
-            # - Numeric segments sort numerically
-            # - Shorter versions sort before longer versions when the prefixes
-            #   match exactly
-            local = local[1]
+            # Normalize the full local tuple according to PEP 440:
+            # - lowercase string parts
+            # - convert purely numeric parts to integers
+            normalized = []
+            for part in local:
+                if isinstance(part, int):
+                    normalized.append(part)
+                else:
+                    part = part.lower()
+                    if part.isdigit():
+                        normalized.append(int(part))
+                    else:
+                        normalized.append(part)
+            local_key = tuple(normalized)
 
-        return epoch, release, pre, post, dev, local
+        return epoch, release, pre, post, dev, local_key


### PR DESCRIPTION
## Related Issue \ discussion
This fixes issue #1469 and makes version parsing more robust while maintaining backward compatibility. https://github.com/clearml/clearml/issues/1469

## Patch Description
PEP 440 local versions (e.g. "25.3.0+computecanada") were previously handled incorrectly in `_cmpkey`. The code attempted to access `local[1]`, which fails for single-segment locals and leads to:
    IndexError: tuple index out of range
This commit updates `_cmpkey` to return the entire `local` tuple instead of indexing into it. This ensures correct handling of local version identifiers, consistent with PEP 440’s comparison rules:
- absent local versions → treated as `inf` (sort before those with local)
- present local versions → compared as tuples of numeric / string segments

## Testing Instructions
These functions can serve as test for the patch.
import pytest
from clearml.utilities.version import Version

def test_local_version_single_component():
    v = Version("25.3.0+computecanada")
    assert str(v) == "25.3.0+computecanada"
    # Should not crash, and comparison should follow PEP 440
    assert v == Version("25.3.0+COMPUTECANADA")  # case-insensitive

def test_local_version_multi_component():
    v1 = Version("1.0+abc.def")
    v2 = Version("1.0+ABC.DEF")
    assert v1 == v2
    assert str(v1) == "1.0+abc.def"